### PR TITLE
Introduce compose multiplatform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## Requirements
 - **Android Studio** (latest version recommended)  
 - **Minimum SDK**: 21 (Lollipop)  
-- **Kotlin** and **Jetpack Compose** (now using Compose Multiplatform) for UI
+- **Kotlin** and **Jetpack Compose** (now using Compose Multiplatform for Android and iOS) for UI
 - **Hilt** for dependency injection  
 - **OkHttp/Retrofit** (or similar) to connect to the miner’s API (details may vary)
 
@@ -40,8 +40,9 @@
 1. **Clone or download** this repository.  
 2. **Open** it in Android Studio.  
 3. **Sync** Gradle, ensuring you have all required plugins (Hilt, Compose, etc.).  
-4. **Run** the app on an emulator or physical device connected to the same network as the miner.  
-5. **On first launch**, the Wizard will prompt for the local IP and API Key. If these are valid, the Basic and Advanced screens will become available.
+4. **Run** the Android app on an emulator or physical device connected to the same network as the miner.
+5. **For iOS**, open the `iosApp` project in Xcode and run it on a simulator or device.
+6. **On first launch**, the Wizard will prompt for the local IP and API Key. If these are valid, the Basic and Advanced screens will become available.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## Requirements
 - **Android Studio** (latest version recommended)  
 - **Minimum SDK**: 21 (Lollipop)  
-- **Kotlin** and **Jetpack Compose** for UI  
+- **Kotlin** and **Jetpack Compose** (now using Compose Multiplatform) for UI
 - **Hilt** for dependency injection  
 - **OkHttp/Retrofit** (or similar) to connect to the miner’s API (details may vary)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":shared"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.compose.multiplatform) apply false
     alias(libs.plugins.google.dagger.hilt) apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
     id("com.google.firebase.firebase-perf") version "1.4.2" apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ firebaseBom = "33.7.0"
 firebaseCrashlyticsGradle = "3.0.2"
 kotlin = "2.0.0"
 compose = "2.1.0"
+composeMultiplatform = "1.6.10"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -103,5 +104,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "compose" }
 google-dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 
 

--- a/iosApp/build.gradle.kts
+++ b/iosApp/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.compose.multiplatform)
+}
+
+kotlin {
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val iosMain by getting {
+            dependencies {
+                implementation(project(":shared"))
+            }
+        }
+    }
+}
+
+compose {
+    iosApp()
+}

--- a/iosApp/src/iosMain/kotlin/Main.kt
+++ b/iosApp/src/iosMain/kotlin/Main.kt
@@ -1,0 +1,7 @@
+import kotlinx.cinterop.BetaInteropApi
+import platform.UIKit.UIApplicationMain
+
+@OptIn(BetaInteropApi::class)
+fun main() {
+    UIApplicationMain(0, null, null, "MainViewController")
+}

--- a/iosApp/src/iosMain/kotlin/MainViewController.kt
+++ b/iosApp/src/iosMain/kotlin/MainViewController.kt
@@ -1,0 +1,6 @@
+import androidx.compose.ui.window.ComposeUIViewController
+import com.natio21.nocoiner_control.shared.Greeting
+
+fun MainViewController() = ComposeUIViewController {
+    Greeting("iOS")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Nocoiner-control"
 include(":app")
+include(":shared")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,3 +22,4 @@ dependencyResolutionManagement {
 rootProject.name = "Nocoiner-control"
 include(":app")
 include(":shared")
+include(":iosApp")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 kotlin {
     androidTarget()
     jvm("desktop")
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting {
@@ -17,6 +20,15 @@ kotlin {
         }
         val androidMain by getting
         val desktopMain by getting
+        val iosX64Main by getting
+        val iosArm64Main by getting
+        val iosSimulatorArm64Main by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
+        }
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.compose.multiplatform)
+}
+
+kotlin {
+    androidTarget()
+    jvm("desktop")
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+            }
+        }
+        val androidMain by getting
+        val desktopMain by getting
+    }
+}
+
+android {
+    namespace = "com.natio21.nocoiner_control.shared"
+    compileSdk = 35
+    defaultConfig {
+        minSdk = 26
+        targetSdk = 34
+    }
+}

--- a/shared/src/androidMain/AndroidManifest.xml
+++ b/shared/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.natio21.nocoiner_control.shared" />

--- a/shared/src/commonMain/kotlin/com/natio21/nocoiner_control/shared/Greeting.kt
+++ b/shared/src/commonMain/kotlin/com/natio21/nocoiner_control/shared/Greeting.kt
@@ -1,0 +1,9 @@
+package com.natio21.nocoiner_control.shared
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun Greeting(name: String) {
+    Text("Hello, $name!")
+}


### PR DESCRIPTION
## Summary
- add Compose Multiplatform libraries to version catalog
- create a shared `:shared` module using Kotlin Multiplatform and Compose
- wire the Android app to depend on the new shared module
- mention Compose Multiplatform in README

## Testing
- `./gradlew tasks` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d338cd19483249ea9210173696e7c